### PR TITLE
Fix About section placeholder

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,2 +1,19 @@
 html { scroll-behavior: smooth; }
 
+#about {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    padding: 2rem;
+    font-family: 'Roboto', 'Helvetica Neue', Arial, sans-serif;
+}
+
+#about .profile-picture {
+    width: 150px;
+    height: 150px;
+    border-radius: 50%;
+    object-fit: cover;
+    margin-bottom: 1rem;
+}
+

--- a/index.html
+++ b/index.html
@@ -26,7 +26,8 @@
     </section>
 
     <section id="about">
-        <!-- About section content goes here -->
+        <img src="" alt="Profile Picture" class="profile-picture">
+        <p>Hello! I'm Jane Doe, a software developer with a passion for building great web experiences. This is placeholder text about me.</p>
     </section>
 
     <section id="projects">


### PR DESCRIPTION
## Summary
- keep about section layout but leave the profile image `src` empty
- delete the unused placeholder image
- add an empty `assets/images` directory for future images

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6846d2a2b1e48329a4161f719d5e381c